### PR TITLE
Fix issues for Rails 5.1

### DIFF
--- a/app/views/shared/_theme_copyright.html.erb
+++ b/app/views/shared/_theme_copyright.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-12">
       <div class="copyright">
-        <img class="copyright-logo" src="/assets/avi-logo.jpg" />
+        <img class="copyright-logo" src="<%= asset_path('avi-logo.jpg') %>" />
         <span class="copyright-text"><%= yield %></span>
       </div>
     </div>

--- a/app/views/shared/_theme_header.html.erb
+++ b/app/views/shared/_theme_header.html.erb
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="<%= root_path %>"><img src="/assets/logo.png" alt="..."></a>
+      <a class="navbar-brand" href="<%= root_path %>"><img src="<%= asset_path('logo.png') %>" alt="..."></a>
     </div>
     <div class="collapse navbar-collapse">
       <%= yield %>

--- a/vendor/assets/stylesheets/font-awesome.css.erb
+++ b/vendor/assets/stylesheets/font-awesome.css.erb
@@ -6,8 +6,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('/assets/fontawesome-webfont.eot?v=4.3.0');
-  src: url('/assets/fontawesome-webfont.eot?#iefix&v=4.3.0') format('embedded-opentype'), url('/assets/fontawesome-webfont.woff2?v=4.3.0') format('woff2'), url('/assets/fontawesome-webfont.woff?v=4.3.0') format('woff'), url('/assets/fontawesome-webfont.ttf?v=4.3.0') format('truetype'), url('/assets/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') format('svg');
+  src: url(<%= asset_path('fontawesome-webfont.eot?v=4.3.0') %>);
+  src: url(<%= asset_path('fontawesome-webfont.eot?#iefix&v=4.3.0') %>) format('embedded-opentype'), url(<%= asset_path('fontawesome-webfont.woff2?v=4.3.0') %>) format('woff2'), url(<%= asset_path('fontawesome-webfont.woff?v=4.3.0') %>) format('woff'), url(<%= asset_path('fontawesome-webfont.ttf?v=4.3.0') %>) format('truetype'), url(<%= asset_path('fontawesome-webfont.svg?v=4.3.0#fontawesomeregular') %>) format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
@brinehart @dwojcAVI Here's the fix for the asset issues we were seeing with the new tools app.  Looks like something changed in newer versions of rails that made these hard coded paths not work anymore.  Using the `asset_path` helper seems to do the trick. I'm going to go ahead and cut a release for this and update the tools repo version.  